### PR TITLE
Logging Infrastructure using ELK and Helm charts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -457,3 +457,9 @@ go_repository(
     commit = "b28fcf2b08a19742b43084fb40ab78ac6c3d8067",
     importpath = "golang.org/x/oauth2",
 )
+
+go_repository(
+    name = "com_github_joonix_log",
+    commit = "9f489441df72b5a985b0ee0423850c7999a3a09b",
+    importpath = "github.com/joonix/log",
+)

--- a/ci/BUILD.bazel
+++ b/ci/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_google_go_github//github:go_default_library",
+        "@com_github_joonix_log//:go_default_library",
         "@com_github_kelseyhightower_envconfig//:go_default_library",
         "@com_github_phayes_hookserve//hookserve:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -34,7 +35,11 @@ go_http_server(
         ":ci.sh",
     ],
     library = ":go_default_library",
-    secrets = ["github/token", "github/username", "github/password"],
+    secrets = [
+        "github/token",
+        "github/username",
+        "github/password",
+    ],
 )
 
 go_binary(

--- a/docs/design/LoggingInfra.md
+++ b/docs/design/LoggingInfra.md
@@ -23,58 +23,54 @@ EOF
 Install elasticsearch
 ---------------------
 
-\`\``$ cat elasticsearch.yaml
-
-Versions available:
-===================
-
-https://hub.docker.com/r/centerforopenscience/elasticsearch/tags/
-=================================================================
-
-appVersion: "6.1"
-
-image: repository: "centerforopenscience/elasticsearch" tag: "6.1" pullPolicy: "IfNotPresent"
 
 ```
-
-```
-
-$ helm install incubator/elasticsearch --namespace $USER --name es-release --set data.storageClass=ssd,data.storage=100Gi -f elasticsearch.yaml
-
+$ helm install incubator/elasticsearch --namespace logging --name es-release -f elasticsearch.yaml
 ```
 
 If you do something wrong, the command to update an existing chart release is:
+
 ```
-
-$ helm upgrade es-release incubator/elasticsearch --namespace $USER -f elasticsearch.yaml
-
+$ helm upgrade es-release incubator/elasticsearch --namespace logging -f elasticsearch.yaml
 ```
 
 ## Kibana
 
 ```
-
-$ cat kibana.yaml env:
-
-```
-    ELASTICSEARCH_URL: "http://my-release-elasticsearch-client.yves.svc.cluster.local:9200"
-```
-
-```
-
-```
-
-$ helm install stable/kibana --name kibana-release --namespace $USER -f kibana.yaml
-
+$ helm install stable/kibana --name kibana-release --namespace logging -f kibana.yaml
 ```
 
 If you do something wrong, the command to update an existing chart release is:
-```
-
-$ helm upgrade kibana-release stable/kibana --namespace $USER -f kibana.yaml
 
 ```
-
+$ helm upgrade kibana-release stable/kibana --namespace logging -f kibana.yaml
 ```
 
-$ export POD_NAME=$(kubectl get pods --namespace yves -l "app=kibana,release=kibana-release" -o jsonpath="{.items[0].metadata.name}") $ kubectl -n $USER port-forward $POD_NAME 5601:5601 \`\`\`
+```
+$ export POD_NAME=$(kubectl get pods --namespace logging -l "app=kibana,release=kibana-release" -o jsonpath="{.items[0].metadata.name}")
+$ kubectl -n logging port-forward $POD_NAME 5601:5601
+```
+
+Fluent-bit
+=======
+
+This awesome thing sends all your logs to ES. 
+
+TODO: should it be deployed in the logging namespace, too? Does it make any difference?
+
+``` 
+helm install --name fluent-bit-release stable/fluent-bit --namespace logging -f fluent-bit.yaml
+```
+NOTE: changes to the config don't seem to reflect live after `helm upgrade`, not even with `--recreate-pods` or `--force`.
+
+Test it out
+=====
+
+Generate some logs
+
+```
+$ kubectl create -n default -f https://k8s.io/docs/tasks/debug-application-cluster/counter-pod.yaml
+pod "counter" created
+```
+
+Go to the kibana dashboard, which should be accessible after the second port-forward above: http://localhost:5601.

--- a/docs/design/LoggingInfra.md
+++ b/docs/design/LoggingInfra.md
@@ -1,76 +1,49 @@
 Logging Infra
 =============
 
-ELK deployed via Helm charts.
+We'll use an ELK cluster to aggregate logs, and fluent-bit to collect all logs from the nodes.
 
-TODO: Move everything into a Bazel rule?
+This provides:
+- nice UI for users (Kibana)
+- searches (e.g: CI build log for a certain commit)
+- aggregation (e.g: total number of CI builds by a user)
 
-StorageClass on GCP
--------------------
+Magically, it also aggregates *all* our kubernetes logs, for the entire infrastructure.
 
+If YourBase apps that use the right kind of log format, they'll get all of the nice stuff for free (in fact, we can help enforce that).
+
+ElasticSearch, Kibana and fluent-bit will all be deployed via Helm charts.
+
+# Installation
+
+For now, the charts are not part of our Bazel graph, so users have to download and use helm as a separate thing. That's not cool. I really don't want to add new things. I'd rather ask users to do "bazel run :cluster" and everything gets deployed/updated for them.
+
+Currently we have just a shell script that installs everything. It's idempotent so it can be run multiple times to update things. 
+
+I have some ideas for how to make this nice and proper inside Bazel, see [Helm](Helm.md) and [BazelOrNot](BazelOrNot.md).
+
+## Kibana Port Forward
+
+```bash
+export POD_NAME=$(kubectl get pods --namespace logging -l "app=kibana,release=kibana-release" -o jsonpath="{.items[0].metadata.name}")
+
+kubectl -n logging port-forward $POD_NAME 5601:5601
 ```
-$ kubectl create -f - <<EOF
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: ssd
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-ssd
-EOF
-```
-
-Install elasticsearch
----------------------
-
-
-```
-$ helm install incubator/elasticsearch --namespace logging --name es-release -f elasticsearch.yaml
-```
-
-If you do something wrong, the command to update an existing chart release is:
-
-```
-$ helm upgrade es-release incubator/elasticsearch --namespace logging -f elasticsearch.yaml
-```
-
-## Kibana
-
-```
-$ helm install stable/kibana --name kibana-release --namespace logging -f kibana.yaml
-```
-
-If you do something wrong, the command to update an existing chart release is:
-
-```
-$ helm upgrade kibana-release stable/kibana --namespace logging -f kibana.yaml
-```
-
-```
-$ export POD_NAME=$(kubectl get pods --namespace logging -l "app=kibana,release=kibana-release" -o jsonpath="{.items[0].metadata.name}")
-$ kubectl -n logging port-forward $POD_NAME 5601:5601
-```
-
-Fluent-bit
-=======
-
-This awesome thing sends all your logs to ES. 
-
-TODO: should it be deployed in the logging namespace, too? Does it make any difference?
-
-``` 
-helm install --name fluent-bit-release stable/fluent-bit --namespace logging -f fluent-bit.yaml
-```
-NOTE: changes to the config don't seem to reflect live after `helm upgrade`, not even with `--recreate-pods` or `--force`.
 
 Test it out
 =====
 
-Generate some logs
+Generate some logs:
 
 ```
-$ kubectl create -n default -f https://k8s.io/docs/tasks/debug-application-cluster/counter-pod.yaml
+kubectl create -n default -f https://k8s.io/docs/tasks/debug-application-cluster/counter-pod.yaml
 pod "counter" created
+```
+
+Or alternatively run a CI live_test.sh (assuming the CI server is running on your namespace):
+
+```
+ci/tools/live_test.sh
 ```
 
 Go to the kibana dashboard, which should be accessible after the second port-forward above: http://localhost:5601.

--- a/docs/design/LoggingInfra.md
+++ b/docs/design/LoggingInfra.md
@@ -1,0 +1,80 @@
+Logging Infra
+=============
+
+ELK deployed via Helm charts.
+
+TODO: Move everything into a Bazel rule?
+
+StorageClass on GCP
+-------------------
+
+```
+$ kubectl create -f - <<EOF
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+EOF
+```
+
+Install elasticsearch
+---------------------
+
+\`\``$ cat elasticsearch.yaml
+
+Versions available:
+===================
+
+https://hub.docker.com/r/centerforopenscience/elasticsearch/tags/
+=================================================================
+
+appVersion: "6.1"
+
+image: repository: "centerforopenscience/elasticsearch" tag: "6.1" pullPolicy: "IfNotPresent"
+
+```
+
+```
+
+$ helm install incubator/elasticsearch --namespace $USER --name es-release --set data.storageClass=ssd,data.storage=100Gi -f elasticsearch.yaml
+
+```
+
+If you do something wrong, the command to update an existing chart release is:
+```
+
+$ helm upgrade es-release incubator/elasticsearch --namespace $USER -f elasticsearch.yaml
+
+```
+
+## Kibana
+
+```
+
+$ cat kibana.yaml env:
+
+```
+    ELASTICSEARCH_URL: "http://my-release-elasticsearch-client.yves.svc.cluster.local:9200"
+```
+
+```
+
+```
+
+$ helm install stable/kibana --name kibana-release --namespace $USER -f kibana.yaml
+
+```
+
+If you do something wrong, the command to update an existing chart release is:
+```
+
+$ helm upgrade kibana-release stable/kibana --namespace $USER -f kibana.yaml
+
+```
+
+```
+
+$ export POD_NAME=$(kubectl get pods --namespace yves -l "app=kibana,release=kibana-release" -o jsonpath="{.items[0].metadata.name}") $ kubectl -n $USER port-forward $POD_NAME 5601:5601 \`\`\`

--- a/helm/elasticsearch.yaml
+++ b/helm/elasticsearch.yaml
@@ -1,0 +1,11 @@
+# Versions available:
+# https://hub.docker.com/r/centerforopenscience/elasticsearch/tags/
+appVersion: "5.4.3"
+
+image:
+  repository: "centerforopenscience/elasticsearch"
+  tag: "5.4.3"
+  pullPolicy: "IfNotPresent"
+
+#rbac:
+#  create: true

--- a/helm/elasticsearch.yaml
+++ b/helm/elasticsearch.yaml
@@ -1,11 +1,19 @@
 # Versions available:
 # https://hub.docker.com/r/centerforopenscience/elasticsearch/tags/
-appVersion: "5.4.3"
+# The tags in this image don't have the minor versions to match with the
+# official ES versions, which may result in deployments of ES and Kibana not
+# matching identically in the minor version. That's probably OK, but Kibana
+# prints a warning about it.
+appVersion: "5.4"
 
 image:
   repository: "centerforopenscience/elasticsearch"
-  tag: "5.4.3"
+  tag: "5.4"
   pullPolicy: "IfNotPresent"
+
+data:
+  storageClass: "ssd"
+  storage: "100Gi"
 
 #rbac:
 #  create: true

--- a/helm/fluent-bit.yaml
+++ b/helm/fluent-bit.yaml
@@ -1,0 +1,9 @@
+image:
+  fluent_bit:
+    tag: 0.12.11
+
+backend:
+  type: es
+  es:
+    host: es-release-elasticsearch-client.logging.svc.cluster.local
+    port: 9200

--- a/helm/fluent-bit.yaml
+++ b/helm/fluent-bit.yaml
@@ -7,3 +7,7 @@ backend:
   es:
     host: es-release-elasticsearch-client.logging.svc.cluster.local
     port: 9200
+
+filter:
+  # Depends on https://github.com/kubernetes/charts/pull/3387
+  mergeJSONLog: true

--- a/helm/kibana.yaml
+++ b/helm/kibana.yaml
@@ -2,7 +2,7 @@
 # https://www.docker.elastic.co/
 appVersion: "5.4.2"
 env:
-        ELASTICSEARCH_URL: "http://es-release-elasticsearch-client.yves.svc.cluster.local:9200"
+        ELASTICSEARCH_URL: "http://es-release-elasticsearch-client.logging.svc.cluster.local:9200"
 
 image:
   tag: "5.4.2"

--- a/helm/kibana.yaml
+++ b/helm/kibana.yaml
@@ -1,0 +1,15 @@
+# versions:
+# https://www.docker.elastic.co/
+appVersion: "5.4.2"
+env:
+        ELASTICSEARCH_URL: "http://es-release-elasticsearch-client.yves.svc.cluster.local:9200"
+
+image:
+  tag: "5.4.2"
+  repository: "kibana"
+  pullPolicy: "IfNotPresent"
+
+ingress:
+   enabled: true
+   hosts:
+     - "kibana.yourbase.net"

--- a/helm/kibana.yaml
+++ b/helm/kibana.yaml
@@ -8,8 +8,3 @@ image:
   tag: "5.4.2"
   repository: "kibana"
   pullPolicy: "IfNotPresent"
-
-ingress:
-   enabled: true
-   hosts:
-     - "kibana.yourbase.net"

--- a/helm/run.sh
+++ b/helm/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eu
+
+# Setup a storage class on GCP. OK if the already exists.
+kubectl create -f - <<EOF 2>&1 |grep -v exists || true
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+EOF
+
+# Install elasticsearch
+helm upgrade es-release incubator/elasticsearch --install --namespace logging -f elasticsearch.yaml
+
+# Install kibana
+helm upgrade kibana-release stable/kibana --install --namespace logging -f kibana.yaml
+
+# Install fluent-bit to send all container logs to ELK
+# NOTE: This may require a force delete and a recreation other it doesn't seem
+# to act on config changes.
+helm upgrade fluent-bit-release stable/fluent-bit --install --namespace logging -f fluent-bit.yaml
+
+echo 'Now try doing a Kibana port-forward so you can access the dashboard at http://localhost:5601/'
+echo
+echo 'export POD_NAME=$(kubectl get pods --namespace logging -l "app=kibana,release=kibana-release" -o jsonpath="{.items[0].metadata.name}")'
+echo
+echo 'kubectl -n logging port-forward $POD_NAME 5601:5601'


### PR DESCRIPTION
This was easier than I thought. This is most of what we needed for #8 and helps with #24.

We have a fully working ELK stack, along with a repeatable installation procedure. All kubernetes logs are now sent to the ElasticSearch (ES). The CI build logs are streamed to stdout using JSON string maps understood by fluent-bit, so we can use ES/Kibana for doing cool things with the build results.

![image](https://user-images.githubusercontent.com/202998/35193447-50043226-fe57-11e7-9fe6-08be14a5a6db.png)

For now, the fluent-bit + ELK  setup works best with this patch to the fluent-bit helm chart: https://github.com/kubernetes/charts/pull/3387

Without it, the CI logs are seen as opaque messages by ES, rather than structured JSON log entries.

For now, the Helm charts are not part of our Bazel code, so they are not deployed in a hermetic way, and deploying them can be intimidating for users. I plan to simplify this. My goal is for anyone to be able to reliably deploy or upgrade a YourBase cluster with a single command.

